### PR TITLE
Fix encoder for time and date

### DIFF
--- a/src/DataPointTypes/DPT10.ts
+++ b/src/DataPointTypes/DPT10.ts
@@ -32,6 +32,8 @@ export const DPT10: DPT = {
         }
         const buf = Buffer.alloc(3);
         buf.writeUInt8((value.hours & 0x1F) | (value.day << 5), 0);
+        buf.writeUInt8(value.minutes & 0x3F, 1);
+        buf.writeUInt8(value.seconds & 0x3F, 2);
         return buf;
     }
 };

--- a/src/DataPointTypes/DPT11.ts
+++ b/src/DataPointTypes/DPT11.ts
@@ -28,14 +28,27 @@ export const DPT11: DPT = {
         return {year, month, day};
     },
     encoder: (value: DPT11Value): Buffer => {
-        if (!(value instanceof Date)) {
+        let year, month, day;
+
+        if (value instanceof Date) {
+          year = value.getFullYear();
+          month = value.getMonth() + 1;
+          day = value.getDay();
+        } else {
+          year = value.year;
+          month = value.month;
+          day = value.day;
+        }
+
+        if (! (year && month && day)) {
             throw new Error(`Unexpected Date format - ${value}`);
         }
+        
         const buf = Buffer.alloc(3);
-        buf.writeUInt8(value.getDay(), 0);
-        buf.writeUInt8(value.getMonth() + 1, 1);
-        const year = value.getFullYear();
+        buf.writeUInt8(day, 0);
+        buf.writeUInt8(month, 1);
         buf.writeUInt8(year - (year > 2000 ? 2000 : 1900), 2);
+
         return buf;
     }
 };


### PR DESCRIPTION
Encoder for date (DPT11) is expecting data different from the decoder output. Enhanced encoder to accept both { year, month, day } object and Javascript Date Object

Encoder for time (DPT10) is missing minutes and seconds in buffer.